### PR TITLE
feat(copilot): stow shared skills

### DIFF
--- a/config/copilot/.copilot/skills/claude
+++ b/config/copilot/.copilot/skills/claude
@@ -1,0 +1,1 @@
+../../../claude/.claude/skills

--- a/stow-all.sh
+++ b/stow-all.sh
@@ -19,6 +19,7 @@ cd "$CONFIG_DIR" || exit 1
 
 packages=(
   codex
+  copilot
   tmux
   zsh
   git


### PR DESCRIPTION
## Summary
- add the copilot package to `stow-all.sh`
- link GitHub Copilot skills to the shared Claude skills directory

## Notes
- no repo lint command was identified, so lint was skipped